### PR TITLE
Draft of Manifest JSON schema model

### DIFF
--- a/schema/python/api-swagger.yaml
+++ b/schema/python/api-swagger.yaml
@@ -1,0 +1,327 @@
+swagger: "2.0"
+basePath: /v1
+paths:
+  /manifest:
+    get:
+      summary: gets an artifact manifest
+      description: |
+        Obtains a JSON manifest conforming to the Model Schema.
+        
+        Returns **200** on success and **404** on error with details in the
+        output JSON
+      parameters:
+        - name: digest
+          in: query
+          required: true
+          pattern: '^[a-fA-F0-9]{32}$'
+          description: Digest of an artifact archive for which to fetch the manifest
+          type: string
+        - name: version
+          in: query
+          required: false
+          description: Optional Manifest Schema Version of the response manifest
+          type: object
+          schema:
+            $ref: '#/definitions/version'
+      responses:
+        '200':
+          description: an artifact manifest
+          schema:
+            $ref: '#/definitions/manifest'
+  /dependency/{ecosystem}:
+    get:
+      summary: gets manifest about target dependency
+      description: |
+        Given input dependency specification in the form of `abstract-dependency` searches the metadata database of given `ecosystem` and returns JSON manifest conforming to the Model schema.
+        
+        Returns **200** on success and **404** on error with details in the
+        output JSON
+      parameters:
+        - name: ecosystem
+          in: path
+          required: true
+          description: dependncy ecosystem
+          type: string
+        - name: specification
+          in: query
+          required: true
+          description: Dependency specification
+          schema:
+            $ref: '#/definitions/abstract-dependency'
+        - name: version
+          in: query
+          required: false
+          description: Optional Manifest Schema Version of the response manifest
+          schema:
+            $ref: '#/definitions/version'
+      responses:
+        '200':
+          description: dependency artifact manifest
+          schema:
+            $ref: '#/definitions/manifest'
+info:
+  title: CCS API
+  description: CCS Data model and API endpoints
+  version: 1.0.0
+definitions:
+  manifest:
+    properties:
+      dependencies:
+        description: list of artifact dependencies
+        type: array
+        items:
+          - $ref: '#/definitions/abstract-dependency'
+          - $ref: '#/definitions/range-dependency'
+          - $ref: '#/definitions/version-dependency'
+          - $ref: '#/definitions/not-version-dependency'
+          - $ref: '#/definitions/and-version-dependency'
+          - $ref: '#/definitions/or-version-dependency'
+        uniqueItems: true
+      licenses:
+        description: licenses applicable to the artifact
+        type: array
+        items:
+          type: string
+      manifest_version:
+        $ref: '#/definitions/version'
+      artifact_version:
+        $ref: '#/definitions/version'
+      archive:
+        $ref: '#/definitions/archive'
+      provides:
+        description: list of provided files
+        type: array
+        items:
+          $ref: '#/definitions/file-provide'
+      name:
+        description: name of the artifact
+        type: string
+        pattern: "^[A-Za-z0-9_\\-\\.]*$"
+      origin:
+        format: uri
+        description: authoritative source of the artifact
+        type: string
+    type: object
+    required:
+      - artifact_version
+      - manifest_version
+      - name
+  file-trait:
+    properties:
+      is_source:
+        description: true for source files
+        type: boolean
+      language:
+        description: implementation language
+        type: string
+      is_library:
+        description: true for library binaries
+        type: boolean
+      is_executable:
+        description: true for executable binaries
+        type: boolean
+      is_header:
+        description: true for header files
+        type: boolean
+    type: object
+    required:
+      - language
+    additionalProperties: false
+  archive:
+    properties:
+      uri:
+        format: uri
+        description: location of the archive
+        type: string
+      hash:
+        description: sha256 digest of the archive
+        type: string
+        pattern: '^[A-Fa-f0-9]{32}$'
+    type: object
+    additionalProperties: false
+  abstract-dependency:
+    properties:
+      name:
+        description: name of the dependency
+        type: string
+      type:
+        type: string
+        enum:
+          - abstract-dependency
+      source:
+        format: uri
+        description: URI source of the dependency
+        type: string
+    type: object
+    required:
+      - name
+      - type
+    additionalProperties: false
+  version-dependency:
+    properties:
+      name:
+        description: name of the dependency
+        type: string
+      type:
+        type: string
+        enum:
+          - varsion-dependency
+      version:
+        $ref: '#/definitions/version'
+      source:
+        format: uri
+        description: URI source of the dependency
+        type: string
+    type: object
+    required:
+      - name
+      - version
+    additionalProperties: false
+  range-dependency:
+    properties:
+      name:
+        description: name of the dependency
+        type: string
+      type:
+        type: string
+        enum:
+          - range-dependency
+      range:
+        $ref: '#/definitions/version-range'
+      source:
+        format: uri
+        description: URI source of the dependency
+        type: string
+    type: object
+    required:
+      - name
+      - range
+    additionalProperties: false
+  or-version-dependency:
+    properties:
+      items:
+        description: items to join with OR
+        type: array
+        items:
+          $ref: '#/definitions/abstract-dependency'
+      name:
+        description: name of the dependency
+        type: string
+      type:
+        type: string
+        enum:
+          - or-version-dependency
+      source:
+        format: uri
+        description: URI source of the dependency
+        type: string
+    type: object
+    required:
+      - name
+      - items
+    additionalProperties: false
+  and-version-dependency:
+    properties:
+      items:
+        description: items to join with AND
+        type: array
+        items:
+          $ref: '#/definitions/abstract-dependency'
+      name:
+        description: name of the dependency
+        type: string
+      type:
+        type: string
+        enum:
+          - and-version-dependency
+      source:
+        format: uri
+        description: URI source of the dependency
+        type: string
+    type: object
+    required:
+      - name
+      - items
+    additionalProperties: false
+  file-provide:
+    properties:
+      uri:
+        format: uri
+        description: chroot relative uri of the file
+        type: string
+      name:
+        description: basename of the file
+        type: string
+      hash:
+        description: sha256 digest of the file
+        type: string
+        pattern: '^[A-Fa-f0-9]{32}$'
+      architecture:
+        description: architecture description string
+        type: string
+        pattern: "^[A-Za-z0-9_\\-\\.]*$"
+      traits:
+        description: traits of the file
+        type: array
+        items:
+          $ref: '#/definitions/file-trait'
+    type: object
+    additionalProperties: false
+  version:
+    properties:
+      minor:
+        maximum: 999
+        description: minor version number
+        type: number
+        minimum: 0
+      build:
+        maximum: 999
+        description: build version number
+        type: number
+        minimum: 0
+      major:
+        maximum: 999
+        description: major version number
+        type: number
+        minimum: 0
+    type: object
+    required:
+      - major
+    additionalProperties: false
+  version-range:
+    properties:
+      end_exclusive:
+        description: make the end specification exclusive
+        type: boolean
+      version_start:
+        $ref: '#/definitions/version'
+      start_exclusive:
+        description: make the start specification exclusive
+        type: boolean
+      version_end:
+        $ref: '#/definitions/version'
+    type: object
+    required:
+      - version_start
+      - version_end
+    additionalProperties: false
+  not-version-dependency:
+    properties:
+      target:
+        $ref: '#/definitions/abstract-dependency'
+      name:
+        description: name of the dependency
+        type: string
+      type:
+        type: string
+        enum:
+          - not-version-dependency
+      source:
+        format: uri
+        description: URI source of the dependency
+        type: string
+    type: object
+    required:
+      - name
+      - target
+    additionalProperties: false

--- a/schema/python/generated.json
+++ b/schema/python/generated.json
@@ -1,0 +1,376 @@
+{
+  "properties": {
+    "dependencies": {
+      "description": "list of artifact dependencies",
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/abstract-dependency"
+        },
+        {
+          "$ref": "#/definitions/range-dependency"
+        },
+        {
+          "$ref": "#/definitions/version-dependency"
+        },
+        {
+          "$ref": "#/definitions/not-version-dependency"
+        },
+        {
+          "$ref": "#/definitions/and-version-dependency"
+        },
+        {
+          "$ref": "#/definitions/or-version-dependency"
+        }
+      ],
+      "uniqueItems": true
+    },
+    "licenses": {
+      "description": "licenses applicable to the artifact",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "manifest_version": {
+      "$ref": "#/definitions/version"
+    },
+    "artifact_version": {
+      "$ref": "#/definitions/version"
+    },
+    "sources": {
+      "description": "all source archives for the artifact",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/archive"
+      }
+    },
+    "provides": {
+      "description": "list of provided files",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/file-provide"
+      }
+    },
+    "name": {
+      "description": "name of the artifact",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_\\-\\.]*$"
+    },
+    "origin": {
+      "format": "uri",
+      "description": "authoritative source of the artifact",
+      "type": "string"
+    }
+  },
+  "type": "object",
+  "required": [
+    "artifact_version",
+    "manifest_version",
+    "name"
+  ],
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "file-trait": {
+      "properties": {
+        "is_source": {
+          "description": "true for source files",
+          "type": "boolean"
+        },
+        "language": {
+          "description": "implementation language",
+          "type": "string"
+        },
+        "is_library": {
+          "description": "true for library binaries",
+          "type": "boolean"
+        },
+        "is_executable": {
+          "description": "true for executable binaries",
+          "type": "boolean"
+        },
+        "is_header": {
+          "description": "true for header files",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": [
+        "language"
+      ],
+      "additionalProperties": false
+    },
+    "archive": {
+      "properties": {
+        "uri": {
+          "format": "uri",
+          "description": "location of the archive",
+          "type": "string"
+        },
+        "hash": {
+          "description": "sha256 digest of the archive",
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{32}$"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "abstract-dependency": {
+      "properties": {
+        "name": {
+          "description": "name of the dependency",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "abstract-dependency"
+          ]
+        },
+        "source": {
+          "format": "uri",
+          "description": "URI source of the dependency",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "version-dependency": {
+      "properties": {
+        "name": {
+          "description": "name of the dependency",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "varsion-dependency"
+          ]
+        },
+        "version": {
+          "$ref": "#/definitions/version"
+        },
+        "source": {
+          "format": "uri",
+          "description": "URI source of the dependency",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "version"
+      ],
+      "additionalProperties": false
+    },
+    "range-dependency": {
+      "properties": {
+        "name": {
+          "description": "name of the dependency",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "range-dependency"
+          ]
+        },
+        "range": {
+          "$ref": "#/definitions/version-range"
+        },
+        "source": {
+          "format": "uri",
+          "description": "URI source of the dependency",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "range"
+      ],
+      "additionalProperties": false
+    },
+    "or-version-dependency": {
+      "properties": {
+        "items": {
+          "description": "items to join with OR",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/abstract-dependency"
+          }
+        },
+        "name": {
+          "description": "name of the dependency",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "or-version-dependency"
+          ]
+        },
+        "source": {
+          "format": "uri",
+          "description": "URI source of the dependency",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "items"
+      ],
+      "additionalProperties": false
+    },
+    "and-version-dependency": {
+      "properties": {
+        "items": {
+          "description": "items to join with AND",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/abstract-dependency"
+          }
+        },
+        "name": {
+          "description": "name of the dependency",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "and-version-dependency"
+          ]
+        },
+        "source": {
+          "format": "uri",
+          "description": "URI source of the dependency",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "items"
+      ],
+      "additionalProperties": false
+    },
+    "file-provide": {
+      "properties": {
+        "uri": {
+          "format": "uri",
+          "description": "chroot relative uri of the file",
+          "type": "string"
+        },
+        "name": {
+          "description": "basename of the file",
+          "type": "string"
+        },
+        "hash": {
+          "description": "sha256 digest of the file",
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{32}$"
+        },
+        "architecture": {
+          "description": "architecture description string",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_\\-\\.]*$"
+        },
+        "traits": {
+          "description": "traits of the file",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/file-trait"
+          }
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "version": {
+      "properties": {
+        "minor": {
+          "maximum": 999,
+          "description": "minor version number",
+          "type": "number",
+          "minimum": 0
+        },
+        "build": {
+          "maximum": 999,
+          "description": "build version number",
+          "type": "number",
+          "minimum": 0
+        },
+        "major": {
+          "maximum": 999,
+          "description": "major version number",
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "type": "object",
+      "required": [
+        "major"
+      ],
+      "additionalProperties": false
+    },
+    "version-range": {
+      "properties": {
+        "end_exclusive": {
+          "description": "make the end specification exclusive",
+          "type": "boolean"
+        },
+        "version_start": {
+          "$ref": "#/definitions/version"
+        },
+        "start_exclusive": {
+          "description": "make the start specification exclusive",
+          "type": "boolean"
+        },
+        "version_end": {
+          "$ref": "#/definitions/version"
+        }
+      },
+      "type": "object",
+      "required": [
+        "version_start",
+        "version_end"
+      ],
+      "additionalProperties": false
+    },
+    "not-version-dependency": {
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/abstract-dependency"
+        },
+        "name": {
+          "description": "name of the dependency",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "not-version-dependency"
+          ]
+        },
+        "source": {
+          "format": "uri",
+          "description": "URI source of the dependency",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "target"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schema/python/manifest.py
+++ b/schema/python/manifest.py
@@ -1,0 +1,177 @@
+import jsl, json
+# vim: set fileencoding=utf-8
+# Pavel Odvody <podvody@redhat.com>
+#
+# Common Metadata Interchange Format - Python Model
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# 02111-1307 USA
+
+
+""" Well qualified name pattern """
+NAME_PATTERN='^[A-Za-z0-9_\-\.]*$'
+
+class Version(jsl.Document):
+        """ X.Y.Z version specification
+
+        components are called <MAJOR>.<MINOR>.<BUILD>
+        """
+        class Options(object):
+                definition_id = 'version'
+
+        major = jsl.NumberField(minimum=0, maximum=999, required=True, description='major version number')
+        minor = jsl.NumberField(minimum=0, maximum=999, description='minor version number')
+        build = jsl.NumberField(minimum=0, maximum=999, description='build version number')
+
+class VersionRange(jsl.Document):
+        """ Version range specification
+
+        allows specifying both exclusive/inclusive version ranges/sets
+        """
+        class Options(object):
+                definition_id = 'version-range'
+
+        version_start = jsl.DocumentField(Version, as_ref=True, required=True, description='version range start')
+        version_end = jsl.DocumentField(Version, as_ref=True, required=True, description='version range end')
+        start_exclusive = jsl.BooleanField(description='make the start specification exclusive')
+        end_exclusive = jsl.BooleanField(description='make the end specification exclusive')
+
+class AbstractDependency(jsl.Document):
+        """ Base class for dependencies
+
+        each dependency has name and source URI
+        """
+        class Options(object):
+                definition_id = 'abstract-dependency'
+
+        type = jsl.StringField(enum=['abstract-dependency'])
+        name = jsl.StringField(required=True, description='name of the dependency')
+        source = jsl.UriField(description='URI source of the dependency')
+
+class RangeDependency(AbstractDependency):
+        """ Version range dependency
+
+        """
+        class Options(object):
+                definition_id = 'range-dependency'
+
+        type = jsl.StringField(enum=['range-dependency'])
+        range = jsl.DocumentField(VersionRange, as_ref=True, required=True, description='version range dependency')
+
+class VersionDependency(AbstractDependency):
+        """ Exact version dependency
+
+        """
+        class Options(object):
+                definition_id = 'version-dependency'
+
+        type = jsl.StringField(enum=['varsion-dependency'])
+        version = jsl.DocumentField(Version, as_ref=True, required=True, description='exact version dependency')
+
+class NotVersionDependency(AbstractDependency):
+        """ Negates the result of another `AbstractDependency`
+
+        """
+        class Options(object):
+                definition_id = 'not-version-dependency'
+
+        type = jsl.StringField(enum=['not-version-dependency'])
+        target = jsl.DocumentField(AbstractDependency, as_ref=True, required=True, description='version specificaiton to negate')
+
+class AndDependencyGroup(AbstractDependency):
+        """ Collates `items` under `AND` clause
+
+        """
+        class Options(object):
+                definition_id = 'and-version-dependency'
+
+        type = jsl.StringField(enum=['and-version-dependency'])
+        items = jsl.ArrayField(jsl.DocumentField(AbstractDependency, as_ref=True),
+                  required=True, description='items to join with AND')
+
+class OrDependencyGroup(AbstractDependency):
+        """ Collates `items` under `OR` clause
+
+        """
+        class Options(object):
+                definition_id = 'or-version-dependency'
+
+        type = jsl.StringField(enum=['or-version-dependency'])
+        items = jsl.ArrayField(jsl.DocumentField(AbstractDependency, as_ref=True),
+                  required=True, description='items to join with OR')
+
+class FileTrait(jsl.Document):
+        """ Describes basic properties of file provides
+
+        """
+        class Options(object):
+                definition_id = 'file-trait'
+
+        is_executable = jsl.BooleanField(description='true for executable binaries')
+        is_library = jsl.BooleanField(description='true for library binaries')
+        is_header = jsl.BooleanField(description='true for header files')
+        is_source = jsl.BooleanField(description='true for source files')
+        language = jsl.StringField(description='implementation language', required=True)
+
+class FileProvides(jsl.Document):
+        """ Each file should corresopond to exactly one provide
+
+        """
+        class Options(object):
+                definition_id = 'file-provide'
+
+        name = jsl.StringField(description='basename of the file')
+        uri = jsl.StringField(format='uri', description='chroot relative uri of the file')
+        hash = jsl.StringField(pattern='^[A-Fa-f0-9]{32}$', description='sha256 digest of the file')
+        architecture = jsl.StringField(pattern=NAME_PATTERN, description='architecture description string')
+        traits = jsl.ArrayField(
+                   jsl.DocumentField(FileTrait, as_ref=True),
+                   description='traits of the file')
+
+class Archive(jsl.Document):
+        """ Describes a source archives
+
+        """
+        class Options(object):
+                definition_id = 'archive'
+
+        uri = jsl.UriField(description='location of the archive')
+        hash = jsl.StringField(pattern='^[A-Fa-f0-9]{32}$', description='sha256 digest of the archive')
+
+
+class Manifest(jsl.Document):
+        """ Manifest 
+
+        """
+        class Options(object):
+                definition_id = 'manifest'
+
+        artifact_version = jsl.DocumentField(Version, as_ref=True, required=True)
+        manifest_version = jsl.DocumentField(Version, as_ref=True, required=True)
+        sources = jsl.ArrayField(jsl.DocumentField(Archive, as_ref=True), description='all source archives for the artifact')
+        origin = jsl.UriField(description='authoritative source of the artifact')
+        name = jsl.StringField(pattern=NAME_PATTERN, required=True, description='name of the artifact')
+        licenses = jsl.ArrayField(jsl.StringField(), description='licenses applicable to the artifact')
+        dependencies = jsl.ArrayField([jsl.DocumentField(AbstractDependency, as_ref=True), 
+                                   jsl.DocumentField(RangeDependency, as_ref=True),
+                                   jsl.DocumentField(VersionDependency, as_ref=True),
+                                   jsl.DocumentField(NotVersionDependency, as_ref=True),
+                                   jsl.DocumentField(AndDependencyGroup, as_ref=True),
+                                   jsl.DocumentField(OrDependencyGroup, as_ref=True)],
+                        unique_items=True, description='list of artifact dependencies')
+        provides = jsl.ArrayField(jsl.DocumentField(FileProvides, as_ref=True),
+                                description='list of provided files')
+
+print(json.dumps(Manifest().get_schema()))


### PR DESCRIPTION
The `manifest.py` file contains the model objects using the `JSL` Python library for defining JSON schemas. This file can be used in Python code directly, the models are just regular classes with special class variables.
The JSON schema file (`generated.json`) is produced automatically.
